### PR TITLE
 [Day5] - ToDo REST API 리펙토링

### DIFF
--- a/app/src/main/java/com/codesoom/assignment/FrontController.java
+++ b/app/src/main/java/com/codesoom/assignment/FrontController.java
@@ -17,7 +17,7 @@ public class FrontController implements HttpHandler {
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         HttpMethodType method = HttpMethodType.getMethod(exchange.getRequestMethod());
-        Path path = createPath(exchange);
+        Path path = Path.createPath(exchange.getRequestURI().getPath());
         String requestBody = new BufferedReader(new InputStreamReader(exchange.getRequestBody()))
                 .lines()
                 .collect(Collectors.joining("\n"));
@@ -26,33 +26,10 @@ public class FrontController implements HttpHandler {
         switch (context) {
             case TASKS:
                 TaskController taskController = TaskController.getInstance();
-                taskController.execute(exchange, method, path, requestBody);
+                taskController.requestMapping(exchange, method, path, requestBody);
                 break;
             default:
                 ClientError.notFound(exchange);
         }
-    }
-
-    private Path createPath(HttpExchange exchange) {
-        Path path = new Path();
-        String[] pathArr = exchange.getRequestURI().getPath().split("/");
-
-        if (hasPath(pathArr)) {
-            path.setPath(pathArr[1]);
-        }
-
-        if (hasPathVariable(pathArr)) {
-            path.setPathVariable(pathArr[2]);
-        }
-
-        return path;
-    }
-
-    private boolean hasPathVariable(String[] pathArr) {
-        return pathArr.length > 2;
-    }
-
-    private boolean hasPath(String[] pathArr) {
-        return pathArr.length > 0;
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/enums/ContextContainer.java
+++ b/app/src/main/java/com/codesoom/assignment/enums/ContextContainer.java
@@ -2,11 +2,9 @@ package com.codesoom.assignment.enums;
 
 import com.codesoom.assignment.models.Path;
 
-import java.util.Arrays;
-
 public enum ContextContainer {
 
-    TASKS("tasks"),
+    TASKS("/tasks"),
     NOT_EXIST(""),
     ;
 
@@ -21,9 +19,40 @@ public enum ContextContainer {
     }
 
     public static ContextContainer getContext(Path path) {
-        return Arrays.stream(ContextContainer.values())
-                .filter(context -> context.getContextValue().equals(path.getPath()))
-                .findFirst()
-                .orElse(ContextContainer.NOT_EXIST);
+        String exceptPathVariable = Path.getPathWithRemovedLastPath(path);
+
+        for (ContextContainer context : ContextContainer.values()) {
+            if (context.getContextValue().equals(path.getPath())) {
+                return context;
+            }
+
+            if (context.getContextValue().equals(exceptPathVariable)) { // (1)
+                Path.setPathVariable(path); // (2)
+                return context;
+            }
+        }
+
+        return NOT_EXIST;
     }
+    
+/*      (1) 해당 조건이 만족한다는 것은 제일 끝 path가 pathVariable
+
+        해당 로직 설계 이유
+         만약 해당 경로들이 들어온다면..?
+         - /tasks/2
+         - /tasks/giibeom
+
+         현재 context 빈에 등록되어 있는 경로들 (예시)
+            /tasks              -> 얘를 반환해야됨
+            /tasks/test
+            /user/tasks/test
+
+        맨 마지막 패스를 PathVariable이라고 가정하였을 때,
+        그걸 빼고 일치하는 경로가 있으면 해당 context를 반환하도록 하였습니다
+        또한 마지막 패스가 PathVariable이 맞다는 소리이므로 PathVariable 세팅도 진행하였습니다.
+
+
+        (2)
+        call by value이지만 같은 참조값을 바라보기 때문에, 값이 정상적으로 바뀔 것이라고 생각합니다.
+*/
 }

--- a/app/src/main/java/com/codesoom/assignment/enums/HttpMethodType.java
+++ b/app/src/main/java/com/codesoom/assignment/enums/HttpMethodType.java
@@ -24,16 +24,4 @@ public enum HttpMethodType {
                 .findFirst()
                 .orElse(HttpMethodType.NOT_SUPPORT);
     }
-
-    // 위와 아래중에 무엇이 더 나은지 궁금합니다!
-    public static HttpMethodType getMethod1(String method) {
-        return isSupportedMethod(method)
-                ? HttpMethodType.valueOf(method)
-                : HttpMethodType.NOT_SUPPORT;
-    }
-
-    public static boolean isSupportedMethod(String method) {
-        return Arrays.stream(HttpMethodType.values())
-                .anyMatch(methodType -> methodType.getMethodValue().equals(method));
-    }
 }

--- a/app/src/main/java/com/codesoom/assignment/error/ClientError.java
+++ b/app/src/main/java/com/codesoom/assignment/error/ClientError.java
@@ -12,6 +12,11 @@ public class ClientError {
         exchange.getResponseBody().close();
     }
 
+    public static final void methodArgumentTypeMismatch(HttpExchange exchange) throws IOException {
+        exchange.sendResponseHeaders(HttpURLConnection.HTTP_BAD_REQUEST, 0);
+        exchange.getResponseBody().close();
+    }
+
     public static final void notFound(HttpExchange exchange) throws IOException {
         exchange.sendResponseHeaders(HttpURLConnection.HTTP_NOT_FOUND, 0);
         exchange.getResponseBody().close();

--- a/app/src/main/java/com/codesoom/assignment/models/Path.java
+++ b/app/src/main/java/com/codesoom/assignment/models/Path.java
@@ -8,15 +8,37 @@ public class Path {
         return path;
     }
 
-    public void setPath(String path) {
-        this.path = path;
-    }
-
     public String getPathVariable() {
         return pathVariable;
     }
 
-    public void setPathVariable(String pathVariable) {
+    private void setPath(String path) {
+        this.path = path;
+    }
+
+    private void setPathVariable(String pathVariable) {
         this.pathVariable = pathVariable;
+    }
+
+    public static Path createPath(String requestPath) {
+        Path path = new Path();
+        path.setPath(requestPath);
+        return path;
+    }
+
+    public static Path setPathVariable(Path path) {
+        String exceptPathVariable = getPathWithRemovedLastPath(path);
+        String pathVariable = getPathVariable(path);
+        path.setPath(exceptPathVariable);
+        path.setPathVariable(pathVariable);
+        return path;
+    }
+
+    private static String getPathVariable(Path path) {
+        return path.getPath().substring(path.getPath().lastIndexOf("/") + 1);
+    }
+
+    public static String getPathWithRemovedLastPath(Path path) {
+        return path.getPath().substring(0, path.getPath().lastIndexOf("/"));
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/utils/StringUtil.java
+++ b/app/src/main/java/com/codesoom/assignment/utils/StringUtil.java
@@ -1,0 +1,13 @@
+package com.codesoom.assignment.utils;
+
+public class StringUtil {
+
+    public static boolean isNumeric(String str) {
+        try {
+            Long.parseLong(str);
+            return true;
+        } catch(NumberFormatException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Path 관련 프로세스 변경 (requestMapping 메서드)

#### [변경한 계기]
- Path는 본 컨트롤러 메서드(gets, get, create, update, delete)로 오기 전에 이미 아래와 같이 받고 싶은 형태로 변경되어 들어와야 된다고 생각하였습니다

![image](https://user-images.githubusercontent.com/59248326/195831559-4debc3d7-ce11-4e63-9f0f-bb3043c2b203.png)

- 따라서 @PathVariable 역할을 requestMapping 메서드에서 수행하도록 만들어보았습니다


#### [기존]
- PathVariable(id) 값을 본 컨트롤러 메서드 내부에서 변경하였습니다.
- Path의 검증 및 세팅이 다방면에 퍼져있었습니다.
- Path 관련 코드가 외부에 퍼져있었습니다.

#### [변경]
1. TaskController에서 본 컨트롤러 메서드로 가기 전에 reqeustMapping 역할을 모두 수행하고, 본 컨트롤러 메서드로 전달하도록 변경하였습니다.
    - requestMapping 역할
        - request 데이터 체크
        - 본 컨트롤러 메서드에서 받는 매개변수 세팅
        - 매개변수 파라미터 타입 체크
2. path 관련 작업 메서드를 모두 Path 객체로 응집하였습니다.
3. hasPathVariable 삭제
    - hasPathVariable은 순수 path의 depth가 2 이상인 경우가 있을 수 밖에 없는데, 무작정 2번째 인덱스를 pathVariable로 설정하는 것은 논리적 오류라고 판단하였습니다
    - 해당 역할은 ContextContainer에서 context를 찾는 메서드로 위임하였습니다.
4. hasPath 삭제
    - path 자체를 ContextContainer에서 비교하여, 등록되어 있는 path와 일치하는게 없다면 NOT_EXIST로 반환하도록 변경하였으므로 필요가 없어져서 삭제하였습니다.


<br>
<br>



### 질문 1
- 애플리케이션의 흐름도를 수정보완해보았습니다
- 멘토님이 보셨을 때 **보완할 점**이 있을지 **좀 더 좋은 방법이 있을지** 의견을 들어보고 싶습니다!

![image](https://user-images.githubusercontent.com/59248326/195831348-54ed39a3-4afc-475a-8bc5-32b5756b4bd8.png)

<br>

### 질문 2
- 해당 중복코드를 어떻게 제거하면 좋을지 고민 끝에 답이 안나와서 질문드립니다.
- 예외처리(throws)를 사용하지 않고 흐름을 제어하려면 switch문 내에서 return을 사용해야 하는데, 
그렇게 함으로써 GET, PATCH, DELETE에서 중복코드가 발생됩니다…!

![image](https://user-images.githubusercontent.com/59248326/195832580-92de5ea0-2d39-435f-9396-0e7b6fc3e89f.png)



